### PR TITLE
Fix lint issues for Ruff 0.16 compatibility

### DIFF
--- a/gametrack_data.py
+++ b/gametrack_data.py
@@ -29,9 +29,9 @@ GAMEDATA_PATH = (
     / "GameData.sqlite"
 )
 
-TBA_RELEASE_DATE = datetime.datetime(4000, 12, 31, 16, 0, 0)
+TBA_RELEASE_DATE = datetime.datetime(4000, 12, 31, 16, 0, 0, tzinfo=datetime.UTC)
 
-CORE_DATA_EPOCH = datetime.datetime(2001, 1, 1)
+CORE_DATA_EPOCH = datetime.datetime(2001, 1, 1, tzinfo=datetime.UTC)
 
 WIKIDATA_USER_AGENT = "gametrack-data (https://github.com/josh/gametrack-data)"
 
@@ -120,7 +120,14 @@ def _decode_nskeyed_array(data: bytes | None) -> list[str]:
                     result.append(objects[idx])
 
         return result
-    except Exception:
+    except (
+        AttributeError,
+        IndexError,
+        KeyError,
+        plistlib.InvalidFileException,
+        TypeError,
+        ValueError,
+    ):
         return []
 
 
@@ -163,7 +170,7 @@ class Game(TypedDict):
     genres: str
 
 
-def _from_coredata_timestamp(timestamp: int | float) -> datetime.datetime:
+def _from_coredata_timestamp(timestamp: float) -> datetime.datetime:
     return datetime.datetime.fromtimestamp(
         timestamp + 978307200, tz=datetime.timezone.utc
     )
@@ -262,10 +269,7 @@ def _should_retry_wikidata_request(error: Exception) -> bool:
             error.code == http.HTTPStatus.TOO_MANY_REQUESTS or 500 <= error.code < 600
         )
 
-    if isinstance(error, urllib.error.URLError):
-        return True
-
-    return False
+    return isinstance(error, urllib.error.URLError)
 
 
 def _load_wikidata_items(igdb_ids: Iterable[int]) -> dict[int, str]:
@@ -735,7 +739,7 @@ def main() -> None:
                 _write_prom_metrics(f, games)
         exitcode = 0
 
-        exit(exitcode)
+        sys.exit(exitcode)
 
     elif command == "export":
         github_repo: str | None = getattr(args, "gh_repo", None) or os.environ.get(
@@ -767,7 +771,7 @@ def main() -> None:
             )
             exitcode = 0
 
-        exit(exitcode)
+        sys.exit(exitcode)
 
     else:
         parser.print_help()


### PR DESCRIPTION
### Motivation
- Prepare the codebase for Ruff v0.16 by fixing lint violations that would become errors under the upcoming ruleset.
- Improve correctness and clarity around datetime handling, error classification, and exception coverage to reduce false positives from stricter checks.

### Description
- Make sentinel datetimes explicitly timezone-aware by setting `tzinfo=datetime.UTC` for `TBA_RELEASE_DATE` and `CORE_DATA_EPOCH`.
- Narrow the blanket `except Exception:` in `_decode_nskeyed_array` to a small set of expected malformed-input exceptions (`AttributeError`, `IndexError`, `KeyError`, `plistlib.InvalidFileException`, `TypeError`, `ValueError`).
- Simplify the Core Data timestamp annotation by changing the parameter type to `float` in `_from_coredata_timestamp`.
- Simplify Wikidata retry classification by returning `isinstance(error, urllib.error.URLError)` directly and replace interactive `exit()` calls with `sys.exit()` for CLI termination.

### Testing
- Ran Ruff in preview mode with `ruff format --preview .` and `ruff check --preview .`, and then ran stable checks with `ruff format --check .` and `ruff check .`; all reported no issues after fixes.
- Type checks and basic runtime sanity were validated with `uv run mypy .` and `python -m compileall -q gametrack_data.py`, both succeeding.
- Additional repository checks including `git diff --check` completed without reporting problems.
- Note: an attempt to fetch and run `ruff==0.16.0` directly failed due to outbound package access being unavailable, so Ruff 0.15.x preview mode was used to expose and validate the v0.16 lint set in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6e67eddc308326933d6f66ab0c78f0)